### PR TITLE
For #5: add color_scheme to plot.swarmset

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^\.Rproj\.user$
 README.md
 ^data-raw$
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 language: R
+cache: packages

--- a/R/plot.swarmset.R
+++ b/R/plot.swarmset.R
@@ -4,13 +4,15 @@
 #' @param sort_stacks If true, reorder sites from left to right.
 #' @param stacks_per_line If NULL, this is set to the number of selected sites; otherwise, it limits plot width.
 #' @param dotify If true, one amino-acid state per site will be left blank to indicate frequency of the TF form.
+#' @param color_scheme Defines how to color the amino acids in each site.  Default is 'charge' but could also be 'monochrome', 'classic', 'hydrophobicity', or 'chemistry').
 #' @param ... can include "aspect_ratio" to adjust Aspect ratio (width to height) of image and "format" to specify the output image format (default is 'png_print' (600dpi resolution) but can also be 'png' (96dpi), 'pdf', 'svg', or 'jpeg').
 #'
 #' @return An explicit path to the file generated, located in a directory removed at the end of the R session.  NB: You will need to copy this file during run time or else lose it when the R session ends.
 #'
 #' @family swarmset methods
 #' @export
-plot.swarmset <- function(x, sort_stacks=F, stacks_per_line=NULL, dotify=F, ...) {
+plot.swarmset <- function(x, sort_stacks=F, stacks_per_line=NULL, dotify=F,
+                          color_scheme='charge', ...) {
 
     dots <- list(...)
 
@@ -45,13 +47,20 @@ plot.swarmset <- function(x, sort_stacks=F, stacks_per_line=NULL, dotify=F, ...)
         names(x$working_swarm$dotseq_concatamer) <- rownames(x$working_swarm$dot_concatamer)
     }
 
+    # provide a safe fall-back option
+    if (is.null(color_scheme) | !color_scheme %in% c('monochrome', 'charge', 'classic', 'hydrophobicity', 'chemistry'))
+        color_scheme = 'monochrome'
+
+    color_option = paste(" -c", color_scheme)
+
     outfile <- make.logoplot(x$selected_sites,
 	    x$working_swarm,
 	    which(x$working_swarm$is_included),
 	    paste0("swarmset-n", length(which(x$working_swarm$is_included))),
 	    stacks_per_line = stacks_per_line,
 	    dotify=dotify, aspect_ratio=aspect_ratio,
-	    logo_format=format)
+	    logo_format=format,
+	    color_option=color_option)
 
 #    if (format=="png") {
 #        require(png, quietly=T)

--- a/man/plot.swarmset.Rd
+++ b/man/plot.swarmset.Rd
@@ -5,7 +5,7 @@
 \title{Render a logo plot of concatamer forms of clones in working_swarm}
 \usage{
 \method{plot}{swarmset}(x, sort_stacks = F, stacks_per_line = NULL,
-  dotify = F, ...)
+  dotify = F, color_scheme = "charge", ...)
 }
 \arguments{
 \item{x}{A swarmset object populated with working_swarm.}
@@ -15,6 +15,8 @@
 \item{stacks_per_line}{If NULL, this is set to the number of selected sites; otherwise, it limits plot width.}
 
 \item{dotify}{If true, one amino-acid state per site will be left blank to indicate frequency of the TF form.}
+
+\item{color_scheme}{Defines how to color the amino acids in each site.  Default is 'charge' but could also be 'monochrome', 'classic', 'hydrophobicity', or 'chemistry').}
 
 \item{...}{can include "aspect_ratio" to adjust Aspect ratio (width to height) of image and "format" to specify the output image format (default is 'png_print' (600dpi resolution) but can also be 'png' (96dpi), 'pdf', 'svg', or 'jpeg').}
 }

--- a/tests/testthat/test_plot_swarmset.R
+++ b/tests/testthat/test_plot_swarmset.R
@@ -9,6 +9,6 @@ test_that("plot.swarmset creates image file output", {
             aas_file=system.file("extdata",
                                  "CH505-gp160.fasta",
                                  package="lassie")))
-    file_path <- lassie::plot.swarmset(ss)
+    file_path <- lassie:::plot.swarmset(ss)
     expect_true(file.exists(file_path))
 })

--- a/tests/testthat/test_plot_swarmset.R
+++ b/tests/testthat/test_plot_swarmset.R
@@ -1,0 +1,14 @@
+context("plot.swarmset")
+
+test_that("plot.swarmset creates image file output", {
+    
+    # This is only a partial test since it just checks if the expected output 
+    # file exists.  But, if weblogo doesn't get called as expected or crashes
+    # the test will at least detect that.
+    ss <- lassie::swarmset(lassie::swarmtools(tf_loss_cutoff=80,
+            aas_file=system.file("extdata",
+                                 "CH505-gp160.fasta",
+                                 package="lassie")))
+    file_path <- lassie::plot.swarmset(ss)
+    expect_true(file.exists(file_path))
+})


### PR DESCRIPTION
This updates plot.swarmset to call make.logoplot with color_option specified, using a color_scheme argument, as make.timepoint.logos already does.  (make.logoplot's definition has color_option=color_option, so R complains about a recursive reference if the function is called without setting that argument.)  I added a test script to show the before-and-after behavior.  This should fix #5.

(This also sets Travis to cache packages so it can run a bit faster and excludes the Travis configuration from R package management.)