### PR TITLE
Mark weblogo script executable at install time

### DIFF
--- a/configure
+++ b/configure
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+# The zip file provided by https://api.github.com/repos/... (and used by
+# devtools::install_github) doesn't provide executable files, even if the
+# originals were.  This should ensure that weblogo is executable.
+chmod +x inst/python/weblogo-3.4-modified/weblogo


### PR DESCRIPTION
devtools::install_github installs a non-executable copy of the weblogo script (fixes #7).  This adds a configure shell script to mark the weblogo Python script executable automatically when installing.  (This change causes a spurious warning when installing under Windows, because R thinks there's some special configuration that will need to be handled manually.  If that matters, I think an alternative could be to call python itself and pass weblogo as an argument, so the execute bits on the script wouldn't matter.)