### PR TITLE
Make report.variant.frequencies handle one-variant case

### DIFF
--- a/R/compute.variant.frequency.R
+++ b/R/compute.variant.frequency.R
@@ -29,7 +29,7 @@ compute.variant.frequency <- function(S, site, site_ns, tps_mult,
                                    colnames(site_counts)[which(site_totals < min_variant_count)]))
 
     row.order <- order(as.numeric(gsub("[A-Z]", "", rownames(site_counts), ignore.case=T)))
-    site_counts = site_counts[row.order, ]
+    site_counts = site_counts[row.order, , drop = FALSE]
 
     site_ns <- site_ns[row.order] 
 

--- a/tests/testthat/test_report_variant_frequencies.R
+++ b/tests/testthat/test_report_variant_frequencies.R
@@ -1,0 +1,29 @@
+context("report.variant.frequencies")
+
+# Example alignment with a single varying site
+seqs <- c("0.0"="MRKPIH",
+          "1.0"="MMKPIH", "1.1"="MMKPIH", "1.2"="MRKPIH", "1.3"="MRKPIH",
+          "2.0"="MMKPIH", "2.1"="MMKPIH", "2.2"="MKKPIH", "2.3"="MKKPIH",
+          "3.0"="MMKPIH", "3.1"="MMKPIH", "3.2"="MKKPIH", "3.3"="MKKPIH")
+test_aln <- matrix(unlist(sapply(seqs, strsplit, split="")),
+              nrow=length(seqs),
+              byrow=TRUE)
+rownames(test_aln) <- names(seqs)
+rm(seqs)
+
+test_that("plots with no errors", {
+    A <- lassie::swarmtools(aas_aln = test_aln, tf_loss_cutoff=80)
+    # Don't save plot image (https://stackoverflow.com/a/24762900)
+    pdf(file = NULL)
+    report.variant.frequencies(A)
+    dev.off()
+})
+
+test_that("plots with no errors for single-variant case", {
+    # replace one site with a single AA, but different from the TF
+    test_aln[2:nrow(test_aln), 2] <- "M"
+    A <- lassie::swarmtools(aas_aln = test_aln, tf_loss_cutoff=80)
+    pdf(file = NULL)
+    report.variant.frequencies(A)
+    dev.off()
+})


### PR DESCRIPTION
This updates compute.variant.frequency so when it indexes site_counts it doesn't inadvertently drop a dimension and create a vector.  This way, report.variant.frequencies is able to plot sites with only a single notable change from the transmitted founder, so this fixes #11.